### PR TITLE
Ensure correct 'ls' module loaded.

### DIFF
--- a/runcoms/zpreztorc
+++ b/runcoms/zpreztorc
@@ -30,6 +30,7 @@ zstyle ':prezto:load' pmodule \
   'history' \
   'directory' \
   'spectrum' \
+  'gnu-utility' \
   'utility' \
   'completion' \
   'prompt' \


### PR DESCRIPTION
See: https://github.com/sorin-ionescu/prezto/issues/966

Adding the gnu-utility module before utility,
resolves a name conflict with recent brew-installed coreutils packages.